### PR TITLE
chore(npm): init npm with commitizen, gulp, mocha, chai and semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+language: node_js
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false
+node_js:
+  - '4'
+before_install:
+  - npm i -g npm@^2.0.0
+before_script:
+  - npm prune
+after_success:
+  - npm run semantic-release
+branches:
+  except:
+    - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "pathbuilder-gulp",
+  "description": "A small library to generate gulp paths from a json object",
+  "main": "index.js",
+  "scripts": {
+    "test": "gulp",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/belgac/pathbuilder-gulp.git"
+  },
+  "author": "Hans Scheuren <hans.scheuren@bizliner.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/belgac/pathbuilder-gulp/issues"
+  },
+  "homepage": "https://github.com/belgac/pathbuilder-gulp#readme",
+  "devDependencies": {
+    "chai": "^3.4.1",
+    "cz-conventional-changelog": "^1.1.5",
+    "gulp": "^3.9.0",
+    "gulp-mocha": "^2.2.0",
+    "mocha": "^2.3.4",
+    "semantic-release": "^4.3.5"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  }
+}


### PR DESCRIPTION
nit the npm package.json, install gulp and the test tools, install and setup commitizen to enforce
the respect of angular commit message format and install and setup semantic-release to automagically
generate semver compliant version numbers and a CHANGELOG.MD file
